### PR TITLE
Improve GNOME 50 compatibility and reduce unnecessary lockscreen background refreshes (latest one)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+.idea/
+
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+

--- a/src/v-45-46-47-48-49-50/extension.js
+++ b/src/v-45-46-47-48-49-50/extension.js
@@ -44,6 +44,7 @@ export default class LockscreenExtension extends Extension {
         this._indicator = null;
         this._sessionModeChangedId = null;
         this._backgroundRefreshSourceId = null;
+        this._backgroundOverrideInstalled = false;
         this._onSettingsChanged = this._queueBackgroundRefresh.bind(this);
 
         this._onSessionModeChanged(Main.sessionMode);
@@ -59,8 +60,18 @@ export default class LockscreenExtension extends Extension {
 
         this._injectionManager = new InjectionManager();
 
-        // override _createBackground method
-        this._injectionManager.overrideMethod(Main.screenShield._dialog, '_createBackground',
+        this._ensureBackgroundOverride();
+    }
+
+    _ensureBackgroundOverride() {
+        if (this._backgroundOverrideInstalled)
+            return;
+
+        const dialog = Main.screenShield?._dialog;
+        if (!dialog || typeof dialog._createBackground !== 'function')
+            return;
+
+        this._injectionManager.overrideMethod(dialog, '_createBackground',
             () => {
                 return monitorIndex => {
                     const n = monitorIndex + 1;
@@ -98,12 +109,12 @@ export default class LockscreenExtension extends Extension {
                         effect: new Shell.BlurEffect(blurEffect),
                     });
 
-                    Main.screenShield._dialog._backgroundGroup.add_child(widget);
+                    dialog._backgroundGroup.add_child(widget);
                 };
             });
 
-        if (Main.screenShield._dialog)
-            Main.screenShield._dialog._updateBackgrounds();
+        this._backgroundOverrideInstalled = true;
+        dialog._updateBackgrounds();
     }
 
     _queueBackgroundRefresh() {
@@ -206,10 +217,12 @@ export default class LockscreenExtension extends Extension {
     }
 
     _onSessionModeChanged(session) {
-        if (session.currentMode === 'unlock-dialog')
+        if (session.currentMode === 'unlock-dialog') {
+            this._ensureBackgroundOverride();
             this._addIndicator();
-        else if (session.currentMode === 'user' || session.parentMode === 'user')
+        } else if (session.currentMode === 'user' || session.parentMode === 'user') {
             this._removeIndicator();
+        }
     }
 
     disable() {
@@ -219,6 +232,7 @@ export default class LockscreenExtension extends Extension {
 
         this._injectionManager.clear(); // clear override method
         this._injectionManager = null;
+        this._backgroundOverrideInstalled = false;
 
         this._disconnectSignals(); // disconnect signals
 

--- a/src/v-45-46-47-48-49-50/extension.js
+++ b/src/v-45-46-47-48-49-50/extension.js
@@ -18,6 +18,7 @@
 
 import St from 'gi://St';
 import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 import Shell from 'gi://Shell';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
@@ -41,8 +42,16 @@ export default class LockscreenExtension extends Extension {
         //
 
         this._indicator = null;
+        this._sessionModeChangedId = null;
+        this._backgroundRefreshSourceId = null;
+        this._onSettingsChanged = this._queueBackgroundRefresh.bind(this);
 
         this._onSessionModeChanged(Main.sessionMode);
+
+        if (!this._sessionModeChangedId)
+            this._sessionModeChangedId = Main.sessionMode.connect('updated', () => {
+                this._onSessionModeChanged(Main.sessionMode);
+            });
 
         this._onVisibilityChange(); // show the extension settings icon on Admin decision
 
@@ -97,6 +106,18 @@ export default class LockscreenExtension extends Extension {
             Main.screenShield._dialog._updateBackgrounds();
     }
 
+    _queueBackgroundRefresh() {
+        if (this._backgroundRefreshSourceId)
+            GLib.Source.remove(this._backgroundRefreshSourceId);
+
+        this._backgroundRefreshSourceId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 30, () => {
+            this._backgroundRefreshSourceId = null;
+            if (Main.screenShield._dialog)
+                Main.screenShield._dialog._updateBackgrounds();
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
     _onChangesFromLockScreen() {
         if (Main.screenShield._dialog)
             Main.screenShield._dialog._updateBackgrounds();
@@ -114,39 +135,20 @@ export default class LockscreenExtension extends Extension {
             `user-background-${n}`,
         ]
             .forEach(key => {
-                this[`_${key}_changedId`] = this._settings.connect(`changed::${key}`, this._onChangesFromLockScreen.bind(this));
+                this[`_${key}_changedId`] = this._settings.connect(`changed::${key}`, this._onSettingsChanged);
             });
     }
 
     _connectionSettings() {
         let nMonitors = Main.layoutManager.monitors.length;
         nMonitors = nMonitors > 4 ? 4 : nMonitors;
-        let n = 1;
-        while (nMonitors > 0) {
-            switch (n) {
-                case 1:
-                    this._callMonitorConnectionSettings(n);
-                    break;
-                case 2:
-                    this._callMonitorConnectionSettings(n);
-                    break;
-                case 3:
-                    this._callMonitorConnectionSettings(n);
-                    break;
-                case 4:
-                    this._callMonitorConnectionSettings(n);
-                    break;
-                default:
-                    break;
-            }
-            n += 1;
-            nMonitors -= 1;
-        }
+        for (let n = 1; n <= nMonitors; n++)
+            this._callMonitorConnectionSettings(n);
 
         let key = 'hide-lockscreen-extension-button';
         this[`_${key}_changedId`] = this._settings.connect(`changed::${key}`, this._onVisibilityChange.bind(this));
         if (!this._systemBgChangedId)
-            this._systemBgChangedId = this._systemBgSettings.connect('changed::picture-uri', this._onChangesFromLockScreen.bind(this));
+            this._systemBgChangedId = this._systemBgSettings.connect('changed::picture-uri', this._onSettingsChanged);
     }
 
     _disconnectSignals() {
@@ -164,11 +166,25 @@ export default class LockscreenExtension extends Extension {
             this._systemBgChangedId = null;
         }
 
+        if (this._sessionModeChangedId) {
+            Main.sessionMode.disconnect(this._sessionModeChangedId);
+            this._sessionModeChangedId = null;
+        }
+
+        if (this._backgroundRefreshSourceId) {
+            GLib.Source.remove(this._backgroundRefreshSourceId);
+            this._backgroundRefreshSourceId = null;
+        }
+
         this._settings = null;
         this._systemBgSettings = null;
+        this._onSettingsChanged = null;
     }
 
     _onVisibilityChange() {
+        if (!this._indicator)
+            return;
+
         if (this._settings.get_boolean('hide-lockscreen-extension-button'))
             this._indicator.hide();
         else

--- a/src/v-45-46-47-48-49-50/metadata.json
+++ b/src/v-45-46-47-48-49-50/metadata.json
@@ -6,6 +6,7 @@
   },
   "name": "Lockscreen Extension",
   "session-modes": [
+    "user",
     "unlock-dialog"
   ],
   "settings-schema": "org.gnome.shell.extensions.lockscreen-extension",

--- a/src/v-45-46-47-48-49-50/utils/getBackgrounds.js
+++ b/src/v-45-46-47-48-49-50/utils/getBackgrounds.js
@@ -17,6 +17,9 @@ import enumerateFiles from './enumerateFiles.js';
 const getBackgrounds = async paths => {
     let backgroundFileNames = [];
     for (const dirName of paths) {
+        if (!dirName)
+            continue;
+
         const dir = Gio.File.new_for_path(dirName);
         if (dir.query_exists(null)) {
             let result = await enumerateFiles(dir);
@@ -25,20 +28,20 @@ const getBackgrounds = async paths => {
         }
     }
 
-    const filtered = backgroundFileNames
+    const filtered = [...new Set(backgroundFileNames)]
         .map(name => name.trim())
+        .filter(name => name.length > 0)
         .filter(
-            name =>
-                name.endsWith('.jpg') ||
-                name.endsWith('.jpeg') ||
-                name.endsWith('.png') ||
-                name.endsWith('.gif') ||
-                name.endsWith('.webp') ||
-                name.endsWith('.JPG') ||
-                name.endsWith('.JPEG') ||
-                name.endsWith('.PNG') ||
-                name.endsWith('.GIF') ||
-                name.endsWith('.WEBP')
+            name => {
+                const lowerName = name.toLowerCase();
+                return (
+                    lowerName.endsWith('.jpg') ||
+                    lowerName.endsWith('.jpeg') ||
+                    lowerName.endsWith('.png') ||
+                    lowerName.endsWith('.gif') ||
+                    lowerName.endsWith('.webp')
+                );
+            }
         );
 
     return filtered;


### PR DESCRIPTION
## Summary
This updates the GNOME 45–50 code path to behave better on GNOME 50 while keeping the older 42–44 branch untouched.

The main goals were:
- improve extension state/session behavior in GNOME 50
- reduce unnecessary lockscreen background refresh work during rapid setting changes

## What changed
- add `user` to `session-modes` in the GNOME 45–50 metadata so the extension participates in normal user-session state handling
- listen for session mode updates so the lockscreen indicator is added/removed more reliably
- debounce lockscreen background refreshes to avoid repeated `_updateBackgrounds()` calls during quick setting updates
- simplify per-monitor settings signal wiring
- guard indicator visibility changes when the indicator is not currently present
- make background enumeration lighter by skipping empty paths, deduplicating results, and normalizing extension checks

## Compatibility
- GNOME 42–44 branch is unchanged
- functional changes are scoped to `src/v-45-46-47-48-49-50`
- install/version selection logic remains unchanged

## Testing
- installed successfully on GNOME 50 using `install.sh`
- manually verified extension install/enable flow for follow-up testing in Extension Manager and lockscreen